### PR TITLE
[QoL] Display only one error

### DIFF
--- a/Backend/Services/AccountService.cs
+++ b/Backend/Services/AccountService.cs
@@ -37,8 +37,7 @@ public class AccountService(UserManager<User> userManager, ITokenService tokenSe
 
     if (!result.Succeeded)
     {
-      var errorString = string.Join(" | ", result.Errors.Select(e => e.Description));
-      return ServiceResult<UserDto>.Failure(400, errorString);
+      return ServiceResult<UserDto>.Failure(400, result.Errors.First().Description);
     }
 
     var userDto = new UserDto

--- a/Frontend/src/app/components/register/register.component.ts
+++ b/Frontend/src/app/components/register/register.component.ts
@@ -81,13 +81,13 @@ export class RegisterComponent implements OnInit {
       ];
       return;
     }
-    this.validationErrors = [];
     this.accountService.register(this.registerForm.value).subscribe({
       next: () => {
         this.router.navigateByUrl(this.redirectUrl);
+        this.validationErrors = [];
       },
       error: (error) => {
-        this.validationErrors.push(error);
+        this.validationErrors = [error];
       },
     });
   }

--- a/Frontend/src/app/components/register/register.component.ts
+++ b/Frontend/src/app/components/register/register.component.ts
@@ -83,8 +83,8 @@ export class RegisterComponent implements OnInit {
     }
     this.accountService.register(this.registerForm.value).subscribe({
       next: () => {
-        this.router.navigateByUrl(this.redirectUrl);
         this.validationErrors = [];
+        this.router.navigateByUrl(this.redirectUrl);
       },
       error: (error) => {
         this.validationErrors = [error];

--- a/Frontend/src/app/components/signin/signin.component.ts
+++ b/Frontend/src/app/components/signin/signin.component.ts
@@ -71,13 +71,13 @@ export class SignInComponent implements OnInit {
       ];
       return;
     }
-    this.validationErrors = [];
     this.accountService.signIn(this.signInForm.value).subscribe({
       next: () => {
+        this.validationErrors = [];
         this.router.navigateByUrl(this.redirectUrl);
       },
       error: (error) => {
-        this.validationErrors.push(error);
+        this.validationErrors = [error];
       },
     });
   }

--- a/Frontend/src/app/interceptors/error.interceptor.ts
+++ b/Frontend/src/app/interceptors/error.interceptor.ts
@@ -16,20 +16,19 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       if (error) {
         switch (error.status) {
           case 400:
+            // We are intentionally only displaying first out of possible multiple errors here
             if (error.error.errors) {
               const errorMap = error.error.errors;
-              const res = [];
-              for (const key in errorMap) {
-                res.push(errorMap[key]);
-              }
-              toast.error('Bad Request');
-              throw res.join(' | ');
+              const firstKey = Object.keys(errorMap)[0];
+              const firstError = errorMap[firstKey][0];
+              toast.error(firstError);
+              throw firstError;
             }
+            // Happens for returned error strings via ServiceResult from the backend
             if (error.error) {
               toast.error(error.error);
               throw error.error;
             }
-
             break;
 
           case 401:


### PR DESCRIPTION
Closes #72 

For the demonstration: I've turned off the minlength validation check on the frontend, to show how the frontend parses validation error responses from the backend, since we don't currently have any error cases that produces an error via backend DTO validation. 

The error messages shown in this video are generated by .NET's DTO validation.

To test just like this video, change the initializeForm() function of `register.component.ts` to this temporarily:

```js
this.registerForm = this.fb.group({
  username: [''], // make this username property [''] to test like the demo
  password: [
    '',
    [
      Validators.required,
      Validators.minLength(8),
      Validators.maxLength(64),
    ],
  ],
  confirmPassword: [
    '',
    [Validators.required, this.matchValues('password')],
  ],
});
```

Video shows a layout shift but that was fixed in https://github.com/robchendev/CoffeeDB/pull/76/commits/080b1d689ab0fe7128da7185c1fe7cf97f6d8ac7

https://github.com/user-attachments/assets/98d426b2-c4e0-4269-ae86-bc91cb4e2eee