### PR TITLE
[UX] Check if active operation is loading by ID

### DIFF
--- a/Frontend/angular.json
+++ b/Frontend/angular.json
@@ -42,10 +42,7 @@
                 "input": "public"
               }
             ],
-            "styles": [
-              "src/styles.scss",
-              "node_modules/ngx-spinner/animations/ball-pulse.css"
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": []
           },
           "configurations": {

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -21,7 +21,6 @@
         "@ng-icons/material-icons": "^32.1.0",
         "@ngneat/overview": "6.1.1",
         "@ngxpert/hot-toast": "^4.2.0",
-        "ngx-spinner": "^19.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -10652,20 +10651,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ngx-spinner": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-spinner/-/ngx-spinner-19.0.0.tgz",
-      "integrity": "sha512-UqmYvLfPyA1AkLw3xGe7NscIiJVG7u9j7NMW10J38Kp8EXv8l/pQdLlqFJS5x70dbRkt90lvOIvEBZM8b/rN7g==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": ">=19.0.0",
-        "@angular/common": ">=19.0.0",
-        "@angular/core": ">=19.0.0"
-      }
     },
     "node_modules/node-addon-api": {
       "version": "6.1.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,7 +23,6 @@
     "@ng-icons/material-icons": "^32.1.0",
     "@ngneat/overview": "6.1.1",
     "@ngxpert/hot-toast": "^4.2.0",
-    "ngx-spinner": "^19.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/Frontend/src/app/app.component.html
+++ b/Frontend/src/app/app.component.html
@@ -1,1 +1,2 @@
+<app-loading-indicator></app-loading-indicator>
 <router-outlet></router-outlet>

--- a/Frontend/src/app/app.component.ts
+++ b/Frontend/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AccountService } from './services/account.service';
+import { LoadingIndicatorComponent } from "./components/loading-indicator/loading-indicator.component";
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, LoadingIndicatorComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/Frontend/src/app/app.config.ts
+++ b/Frontend/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,7 +7,6 @@ import { jwtInterceptor } from './interceptors/jwt.interceptor';
 import { provideHotToastConfig } from '@ngxpert/hot-toast';
 import { loadingInterceptor } from './interceptors/loading.interceptor';
 import { errorInterceptor } from './interceptors/error.interceptor';
-import { NgxSpinnerModule } from 'ngx-spinner';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 export const appConfig: ApplicationConfig = {
@@ -18,6 +17,5 @@ export const appConfig: ApplicationConfig = {
       withInterceptors([errorInterceptor, jwtInterceptor, loadingInterceptor]),
     ),
     provideHotToastConfig(),
-    importProvidersFrom(NgxSpinnerModule),
   ],
 };

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.html
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.html
@@ -41,7 +41,10 @@
     @for (role of availableRoles; track $index) {
       <div
         class="form-check"
-        [class.disabled]="!isAllowedToEditUser(role)"
+        [class.disabled]="
+          !isAllowedToEditUser(role) ||
+          loadingService.isLoadingId(`edit-role-${selectedUser.username}`)
+        "
         (click)="isAllowedToEditUser(role) && updateChecked(role)"
       >
         <input
@@ -49,11 +52,22 @@
           class="checkbox"
           [checked]="selectedUser.roles.includes(role)"
           value="role"
-          [disabled]="!isAllowedToEditUser(role)"
+          [disabled]="
+            !isAllowedToEditUser(role) ||
+            loadingService.isLoadingId(`edit-role-${selectedUser.username}`)
+          "
         />
         <label for="role">{{ role }}</label>
       </div>
     }
-    <button type="submit" (click)="onSubmitRoleEdit()">Submit</button>
+    <button
+      type="submit"
+      (click)="onSubmitRoleEdit()"
+      [disabled]="
+        loadingService.isLoadingId(`edit-role-${selectedUser.username}`)
+      "
+    >
+      Submit
+    </button>
   </app-modal>
 }

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.html
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.html
@@ -1,39 +1,42 @@
 <div>
   <p>Displaying {{ paginationText }} users.</p>
-  @if (paginatedResult) {
-    <app-pagination-controls
-      [(page)]="page"
-      [(pageSize)]="pageSize"
-      [paginatedResult]="paginatedResult"
-      [allowPageSizeEdit]="true"
-      loadingId="user-manager"
-    />
-    <table class="table">
-      <thead>
-        <tr>
-          <th style="width: 10%">ID</th>
-          <th style="width: 30%">Username</th>
-          <th style="width: 40%">Active Roles</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (user of paginatedResult.items; track user.username) {
-          <tr>
-            <td>{{ user.id }}</td>
-            <td>{{ user.username }}</td>
-            <td>{{ user.roles.sort().join(", ") }}</td>
-            <td>
-              <button (click)="showModal(user)">Edit Roles</button>
-            </td>
-          </tr>
-        }
-        <tr></tr>
-      </tbody>
-    </table>
+  @if (loadingService.isLoadingId("user-manager")) {
+    <div>LOADING</div>
+  } @else if (paginatedResult) {
+    <div>LOADED DATA</div>
   } @else {
     <p>Failed to load pagination data.</p>
   }
+  <app-pagination-controls
+    [(page)]="page"
+    [(pageSize)]="pageSize"
+    [paginatedResult]="paginatedResult"
+    [allowPageSizeEdit]="true"
+    loadingId="user-manager"
+  />
+  <table class="table">
+    <thead>
+      <tr>
+        <th style="width: 10%">ID</th>
+        <th style="width: 30%">Username</th>
+        <th style="width: 40%">Active Roles</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (user of paginatedResult?.items; track user.username) {
+        <tr>
+          <td>{{ user.id }}</td>
+          <td>{{ user.username }}</td>
+          <td>{{ user.roles.sort().join(", ") }}</td>
+          <td>
+            <button (click)="showModal(user)">Edit Roles</button>
+          </td>
+        </tr>
+      }
+      <tr></tr>
+    </tbody>
+  </table>
 </div>
 
 @if (selectedUser) {

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.html
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.html
@@ -6,6 +6,7 @@
       [(pageSize)]="pageSize"
       [paginatedResult]="paginatedResult"
       [allowPageSizeEdit]="true"
+      loadingId="user-manager"
     />
     <table class="table">
       <thead>

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
@@ -31,9 +31,14 @@ export class UserManagerComponent {
   availableRoles: string[] = ['Admin', 'Moderator'];
 
   fetchUsersEffect = effect(() => {
+    this.loadingService.busy('user-manager');
     this.adminService.getUserWithRoles(this.page(), this.pageSize()).subscribe({
       next: (response) => {
+        this.loadingService.idle('user-manager');
         this.paginatedResult = getPaginatedResult(response);
+      },
+      error: (error) => {
+        this.loadingService.idle('user-manager');
       },
     });
   });

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
@@ -7,6 +7,7 @@ import { PaginationControlsComponent } from '../../pagination-controls/paginatio
 import { SimpleModalComponent } from '../../modal/modal.component';
 import { AccountService } from '../../../services/account.service';
 import { HotToastService } from '@ngxpert/hot-toast';
+import { LoadingService } from '../../../services/loading.service';
 
 @Component({
   selector: 'app-user-manager',
@@ -18,6 +19,7 @@ export class UserManagerComponent {
   private toast = inject(HotToastService);
   private adminService = inject(AdminService);
   accountService = inject(AccountService);
+  loadingService = inject(LoadingService);
 
   // We are allowing page size change on this component, so we will not be storing
   // pulled paginated data as a cache in a signal, unlike users.service.ts
@@ -57,8 +59,10 @@ export class UserManagerComponent {
 
   onSubmitRoleEdit() {
     if (!this.selectedUser) return;
-
     const { username, roles } = this.selectedUser;
+    const loadingId = `edit-role-${username}`;
+    this.loadingService.busy(loadingId);
+
     this.adminService.editUserRoles(username, roles).subscribe({
       next: (newRoles: string[]) => {
         const updatedUser = this.paginatedResult?.items?.find(
@@ -70,9 +74,15 @@ export class UserManagerComponent {
         }
         updatedUser.roles = newRoles;
         this.toast.success(`Roles modified for ${username}`);
+        this.loadingService.idle(loadingId);
+        this.hideModal();
+      },
+      error: (error) => {
+        this.toast.error(error);
+        this.loadingService.idle(loadingId);
+        this.hideModal();
       },
     });
-    this.hideModal();
   }
 
   updateChecked(value: string) {

--- a/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.html
+++ b/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.html
@@ -1,3 +1,8 @@
-<button [class]="variant()" [type]="type()" (click)="buttonClick.emit()">
+<button
+  [class]="variant()"
+  [type]="type()"
+  (click)="buttonClick.emit()"
+  [disabled]="isLoading()"
+>
   {{ text() }}
 </button>

--- a/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.scss
+++ b/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.scss
@@ -5,7 +5,7 @@
   font-weight: 500;
   border-radius: 999px;
   height: 40px;
-  &:hover {
+  &:not(:disabled):hover {
     background-color: #ffeeee;
   }
 }
@@ -17,7 +17,14 @@
   font-weight: 500;
   border-radius: 999px;
   height: 40px;
-  &:hover {
+  &:not(:disabled):hover {
     background-color: #fff;
+  }
+}
+
+button {
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 }

--- a/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.ts
+++ b/Frontend/src/app/components/forms/form-cta-button/form-cta-button.component.ts
@@ -11,4 +11,5 @@ export class FormCtaButtonComponent {
   text = input.required<string>();
   type = input<'button' | 'submit' | 'reset'>('button');
   variant = input.required<'ephemeral' | 'primary'>();
+  isLoading = input<boolean>(false);
 }

--- a/Frontend/src/app/components/header/header.component.html
+++ b/Frontend/src/app/components/header/header.component.html
@@ -10,7 +10,6 @@
         <div class="badge">Mod</div>
       }
     }
-    <app-loading-indicator />
   </div>
   <div class="end">
     <app-user-handle />

--- a/Frontend/src/app/components/header/header.component.html
+++ b/Frontend/src/app/components/header/header.component.html
@@ -10,8 +10,8 @@
         <div class="badge">Mod</div>
       }
     }
+    <app-loading-indicator />
   </div>
-  <!-- <div class="center">TODO</div> -->
   <div class="end">
     <app-user-handle />
   </div>

--- a/Frontend/src/app/components/header/header.component.ts
+++ b/Frontend/src/app/components/header/header.component.ts
@@ -1,14 +1,18 @@
 import { Component, inject } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { SidebarService } from '../../services/sidebar.service';
 import { MenuButtonComponent } from '../sidebar/menu-button/menu-button.component';
 import { UserHandleComponent } from '../user-handle/user-handle.component';
 import { Router } from '@angular/router';
+import { LoadingIndicatorComponent } from '../loading-indicator/loading-indicator.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [FormsModule, UserHandleComponent, MenuButtonComponent], // TODO: Change to reactive forms later on
+  imports: [
+    UserHandleComponent,
+    MenuButtonComponent,
+    LoadingIndicatorComponent,
+  ],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
 })

--- a/Frontend/src/app/components/header/header.component.ts
+++ b/Frontend/src/app/components/header/header.component.ts
@@ -3,16 +3,11 @@ import { SidebarService } from '../../services/sidebar.service';
 import { MenuButtonComponent } from '../sidebar/menu-button/menu-button.component';
 import { UserHandleComponent } from '../user-handle/user-handle.component';
 import { Router } from '@angular/router';
-import { LoadingIndicatorComponent } from '../loading-indicator/loading-indicator.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [
-    UserHandleComponent,
-    MenuButtonComponent,
-    LoadingIndicatorComponent,
-  ],
+  imports: [UserHandleComponent, MenuButtonComponent],
   templateUrl: './header.component.html',
   styleUrl: './header.component.scss',
 })

--- a/Frontend/src/app/components/loading-indicator/loading-indicator.component.html
+++ b/Frontend/src/app/components/loading-indicator/loading-indicator.component.html
@@ -1,0 +1,5 @@
+<div
+  class="loading-bar"
+  [style.transform]="'scaleX(' + progress() + ')'"
+  [style.opacity]="visible() ? 1 : 0"
+></div>

--- a/Frontend/src/app/components/loading-indicator/loading-indicator.component.scss
+++ b/Frontend/src/app/components/loading-indicator/loading-indicator.component.scss
@@ -1,0 +1,13 @@
+.loading-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 4px;
+  width: 100%;
+  background-color: #ff0000;
+  transform-origin: left;
+  transform: scaleX(0);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 9999;
+}

--- a/Frontend/src/app/components/loading-indicator/loading-indicator.component.ts
+++ b/Frontend/src/app/components/loading-indicator/loading-indicator.component.ts
@@ -1,0 +1,65 @@
+import { Component, effect, inject, signal } from '@angular/core';
+import { LoadingService } from '../../services/loading.service';
+
+@Component({
+  selector: 'app-loading-indicator',
+  standalone: true, // Assuming this is missing in your snippet
+  imports: [],
+  templateUrl: './loading-indicator.component.html',
+  styleUrl: './loading-indicator.component.scss',
+})
+export class LoadingIndicatorComponent {
+  loadingService = inject(LoadingService);
+  progress = signal(0);
+  visible = signal(false);
+  private intervalId: any;
+  private resetTimeoutId: any;
+
+  loadingEffect = effect(() => {
+    if (this.loadingService.isLoading()) {
+      this.startProgress();
+    } else {
+      this.completeProgress();
+    }
+  });
+
+  private startProgress() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+    if (this.resetTimeoutId) {
+      clearTimeout(this.resetTimeoutId);
+      this.resetTimeoutId = null;
+    }
+    this.visible.set(true);
+    this.progress.set(0);
+
+    // Go from 0% → 85% in ~1000ms
+    this.intervalId = setInterval(() => {
+      const progress = this.progress();
+      if (progress < 0.85) {
+        this.progress.set(progress + 0.01);
+      } else {
+        clearInterval(this.intervalId);
+        this.intervalId = null;
+      }
+    }, 12);
+  }
+
+  private completeProgress() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    this.progress.set(1);
+    this.resetTimeoutId = setTimeout(() => {
+      this.visible.set(false);
+      this.resetTimeoutId = setTimeout(() => {
+        this.progress.set(0);
+        this.resetTimeoutId = null;
+      }, 200); // wait for opacity transition
+    }, 200);
+  }
+}

--- a/Frontend/src/app/components/pagination-controls/pagination-controls.component.html
+++ b/Frontend/src/app/components/pagination-controls/pagination-controls.component.html
@@ -1,10 +1,16 @@
 <p>current page: {{ page() }}</p>
-<button (click)="onPageChange(page() - 1)" [disabled]="page() == 1">
+<button
+  (click)="onPageChange(page() - 1)"
+  [disabled]="page() == 1 || loadingService.isLoadingId(loadingId())"
+>
   Prev page
 </button>
 <button
   (click)="onPageChange(page() + 1)"
-  [disabled]="page() == paginatedResult()?.pagination?.totalPages!"
+  [disabled]="
+    page() == paginatedResult()?.pagination?.totalPages! ||
+    loadingService.isLoadingId(loadingId())
+  "
 >
   Next page
 </button>
@@ -14,6 +20,12 @@
     [value]="pageSizeInput"
     type="number"
     (input)="onPageSizeInput($event)"
+    [disabled]="loadingService.isLoadingId(loadingId())"
   />
-  <button (click)="onPageSizeChange()">Execute change page size</button>
+  <button
+    (click)="onPageSizeChange()"
+    [disabled]="loadingService.isLoadingId(loadingId())"
+  >
+    Execute change page size
+  </button>
 }

--- a/Frontend/src/app/components/pagination-controls/pagination-controls.component.ts
+++ b/Frontend/src/app/components/pagination-controls/pagination-controls.component.ts
@@ -1,5 +1,6 @@
-import { Component, input, OnInit, output, Signal } from '@angular/core';
+import { Component, inject, input, OnInit, output } from '@angular/core';
 import { PaginatedResult } from '../../models/pagination';
+import { LoadingService } from '../../services/loading.service';
 
 @Component({
   selector: 'app-pagination-controls',
@@ -8,6 +9,9 @@ import { PaginatedResult } from '../../models/pagination';
   styleUrls: ['./pagination-controls.component.scss'],
 })
 export class PaginationControlsComponent<T> implements OnInit {
+  loadingService = inject(LoadingService);
+  loadingId = input.required<string>();
+
   minPageSize = input<number>(5);
   maxPageSize = input<number>(50);
 

--- a/Frontend/src/app/components/register/register.component.html
+++ b/Frontend/src/app/components/register/register.component.html
@@ -54,6 +54,7 @@
         text="Create account"
         variant="primary"
         type="submit"
+        [isLoading]="loadingService.isLoadingId('create-account')"
       />
     </div>
   </form>

--- a/Frontend/src/app/components/register/register.component.ts
+++ b/Frontend/src/app/components/register/register.component.ts
@@ -10,6 +10,7 @@ import {
 import { TextInputComponent } from '../forms/text-input/text-input.component';
 import { FormCtaButtonComponent } from '../forms/form-cta-button/form-cta-button.component';
 import { matchValues } from '../../utils/form.utils';
+import { LoadingService } from '../../services/loading.service';
 
 @Component({
   selector: 'app-register',
@@ -22,6 +23,7 @@ export class RegisterComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private accountService = inject(AccountService);
+  loadingService = inject(LoadingService);
   private fb = inject(FormBuilder);
   registerForm: FormGroup = new FormGroup({});
   redirectUrl: string = '/';
@@ -69,12 +71,15 @@ export class RegisterComponent implements OnInit {
       ];
       return;
     }
+    this.loadingService.busy('create-account');
     this.accountService.register(this.registerForm.value).subscribe({
       next: () => {
         this.validationErrors = [];
+        this.loadingService.idle('create-account');
         this.router.navigateByUrl(this.redirectUrl);
       },
       error: (error) => {
+        this.loadingService.idle('create-account');
         this.validationErrors = [error];
       },
     });

--- a/Frontend/src/app/components/sandbox/sandbox.component.html
+++ b/Frontend/src/app/components/sandbox/sandbox.component.html
@@ -2,14 +2,9 @@
   <h2>Loading</h2>
   <div class="individual">
     <p>
-      Display loading spinner here in this empty space. There is no trigger
-      button for this, since the loading interceptor calls the loading spinner
-      service. You can invoke the spinner using the buttons within the Errors
-      section below.
+      The header (top of the screen) will show a red loading bar that goes to
+      the right when doing a API call.
     </p>
-    <div class="spinner-container">
-      <ngx-spinner [fullScreen]="false" type="ball-pulse"></ngx-spinner>
-    </div>
     <p></p>
   </div>
   <h2>Toasts</h2>

--- a/Frontend/src/app/components/sandbox/sandbox.component.scss
+++ b/Frontend/src/app/components/sandbox/sandbox.component.scss
@@ -10,8 +10,3 @@
   padding: 12px 8px;
   background: white;
 }
-
-.spinner-container {
-  position: relative;
-  height: 50px;
-}

--- a/Frontend/src/app/components/sandbox/sandbox.component.ts
+++ b/Frontend/src/app/components/sandbox/sandbox.component.ts
@@ -3,11 +3,10 @@ import { HotToastService } from '@ngxpert/hot-toast';
 import { environment } from '../../../environments/environment';
 import { HttpClient } from '@angular/common/http';
 import { LoadingService } from '../../services/loading.service';
-import { NgxSpinnerComponent } from 'ngx-spinner';
 
 @Component({
   selector: 'app-sandbox',
-  imports: [NgxSpinnerComponent],
+  imports: [],
   templateUrl: './sandbox.component.html',
   styleUrl: './sandbox.component.scss',
 })

--- a/Frontend/src/app/components/signin/signin.component.html
+++ b/Frontend/src/app/components/signin/signin.component.html
@@ -31,8 +31,14 @@
         text="Create account"
         variant="ephemeral"
         (buttonClick)="onNavigateRegister()"
+        [isLoading]="loadingService.isLoadingId('signin-account')"
       />
-      <app-form-cta-button text="Sign in" variant="primary" type="submit" />
+      <app-form-cta-button
+        text="Sign in"
+        variant="primary"
+        type="submit"
+        [isLoading]="loadingService.isLoadingId('signin-account')"
+      />
     </div>
   </form>
   <footer>

--- a/Frontend/src/app/components/signin/signin.component.ts
+++ b/Frontend/src/app/components/signin/signin.component.ts
@@ -11,6 +11,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AccountService } from '../../services/account.service';
 import { FormCtaButtonComponent } from '../forms/form-cta-button/form-cta-button.component';
 import { TextInputComponent } from '../forms/text-input/text-input.component';
+import { LoadingService } from '../../services/loading.service';
 
 @Component({
   selector: 'app-signin',
@@ -23,6 +24,7 @@ export class SignInComponent implements OnInit {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private accountService = inject(AccountService);
+  loadingService = inject(LoadingService);
   private fb = inject(FormBuilder);
   signInForm: FormGroup = new FormGroup({});
   redirectUrl: string = '/';
@@ -56,12 +58,15 @@ export class SignInComponent implements OnInit {
       ];
       return;
     }
+    this.loadingService.busy('signin-account');
     this.accountService.signIn(this.signInForm.value).subscribe({
       next: () => {
         this.validationErrors = [];
+        this.loadingService.idle('signin-account');
         this.router.navigateByUrl(this.redirectUrl);
       },
       error: (error) => {
+        this.loadingService.idle('signin-account');
         this.validationErrors = [error];
       },
     });

--- a/Frontend/src/app/components/user-directory/user-directory.component.html
+++ b/Frontend/src/app/components/user-directory/user-directory.component.html
@@ -1,16 +1,18 @@
 <div>
   <h2>User Directory</h2>
-  @if (usersService.paginatedResult()?.pagination) {
-    <app-pagination-controls
-      [(page)]="page"
-      [(pageSize)]="pageSize"
-      [paginatedResult]="usersService.paginatedResult()"
-      loadingId="user-directory"
-    />
+  @if (loadingService.isLoadingId("user-directory")) {
+    <div>LOADING</div>
+  } @else if (usersService.paginatedResult()?.pagination) {
+    <div>LOADED DATA</div>
   } @else {
-    <!-- TODO this is showing up when the data hasn't loaded yet (test throttling Slow 4G) -->
     <p>Failed to load pagination data.</p>
   }
+  <app-pagination-controls
+    [(page)]="page"
+    [(pageSize)]="pageSize"
+    [paginatedResult]="usersService.paginatedResult()"
+    loadingId="user-directory"
+  />
   <ul>
     @for (user of usersService.paginatedResult()?.items; track user.id) {
       <li>{{ user.id }}, {{ user.username }}</li>

--- a/Frontend/src/app/components/user-directory/user-directory.component.html
+++ b/Frontend/src/app/components/user-directory/user-directory.component.html
@@ -5,6 +5,7 @@
       [(page)]="page"
       [(pageSize)]="pageSize"
       [paginatedResult]="usersService.paginatedResult()"
+      loadingId="user-directory"
     />
   } @else {
     <p>Failed to load pagination data.</p>

--- a/Frontend/src/app/components/user-directory/user-directory.component.html
+++ b/Frontend/src/app/components/user-directory/user-directory.component.html
@@ -8,6 +8,7 @@
       loadingId="user-directory"
     />
   } @else {
+    <!-- TODO this is showing up when the data hasn't loaded yet (test throttling Slow 4G) -->
     <p>Failed to load pagination data.</p>
   }
   <ul>

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -17,6 +17,6 @@ export class UserDirectoryComponent {
   pageSize = signal(20);
 
   fetchUsersEffect = effect(() => {
-    this.usersService.getUsers(this.page(), this.pageSize());
+    this.usersService.getUsers(this.page(), this.pageSize(), 'user-directory');
   });
 }

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -3,6 +3,7 @@ import { UsersService } from '../../services/users.service';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PaginationControlsComponent } from '../pagination-controls/pagination-controls.component';
+import { LoadingService } from '../../services/loading.service';
 
 @Component({
   selector: 'app-user-directory',
@@ -13,6 +14,7 @@ import { PaginationControlsComponent } from '../pagination-controls/pagination-c
 })
 export class UserDirectoryComponent {
   usersService = inject(UsersService);
+  loadingService = inject(LoadingService);
   page = signal(1);
   pageSize = signal(20);
 

--- a/Frontend/src/app/components/user-settings/user-settings.component.html
+++ b/Frontend/src/app/components/user-settings/user-settings.component.html
@@ -45,6 +45,7 @@
         text="Change username"
         variant="primary"
         type="submit"
+        [isLoading]="loadingService.isLoadingId('change-username')"
       />
     </form>
     <p>Username requirements:</p>
@@ -119,6 +120,7 @@
         text="Change password"
         variant="primary"
         type="submit"
+        [isLoading]="loadingService.isLoadingId('change-password')"
       />
     </form>
   </div>

--- a/Frontend/src/app/components/user-settings/user-settings.component.ts
+++ b/Frontend/src/app/components/user-settings/user-settings.component.ts
@@ -14,6 +14,7 @@ import {
 } from '../../utils/form.utils';
 import { FormCtaButtonComponent } from '../forms/form-cta-button/form-cta-button.component';
 import { HotToastService } from '@ngxpert/hot-toast';
+import { LoadingService } from '../../services/loading.service';
 
 @Component({
   selector: 'app-user-settings',
@@ -23,6 +24,7 @@ import { HotToastService } from '@ngxpert/hot-toast';
 })
 export class UserSettingsComponent implements OnInit {
   accountService = inject(AccountService);
+  loadingService = inject(LoadingService);
   private fb = inject(FormBuilder);
   changeUsernameForm: FormGroup = new FormGroup({});
   changePasswordForm: FormGroup = new FormGroup({});
@@ -102,15 +104,18 @@ export class UserSettingsComponent implements OnInit {
       ];
       return;
     }
+    this.loadingService.busy('change-username');
     this.accountService
       .changeUsername(this.changeUsernameForm.value)
       .subscribe({
         next: () => {
           this.toast.success('Username updated successfully');
           this.usernameValidationErrors = [];
+          this.loadingService.idle('change-username');
           this.onToggleChangeUsername();
         },
         error: (error) => {
+          this.loadingService.idle('change-username');
           this.usernameValidationErrors = [error];
         },
       });
@@ -124,15 +129,18 @@ export class UserSettingsComponent implements OnInit {
       ];
       return;
     }
+    this.loadingService.busy('change-password');
     this.accountService
       .changePassword(this.changePasswordForm.value)
       .subscribe({
         next: () => {
           this.toast.success('Password updated successfully');
           this.passwordValidationErrors = [];
+          this.loadingService.idle('change-password');
           this.onToggleChangePassword();
         },
         error: (error) => {
+          this.loadingService.idle('change-password');
           this.passwordValidationErrors = [error];
         },
       });

--- a/Frontend/src/app/services/admin.service.ts
+++ b/Frontend/src/app/services/admin.service.ts
@@ -3,6 +3,7 @@ import { environment } from '../../environments/environment.development';
 import { HttpClient } from '@angular/common/http';
 import { User, UserWithRoles } from '../models/user';
 import { getPaginationParams } from '../utils/pagination.utils';
+import { LoadingService } from './loading.service';
 
 @Injectable({
   providedIn: 'root',

--- a/Frontend/src/app/services/loading.service.ts
+++ b/Frontend/src/app/services/loading.service.ts
@@ -11,8 +11,12 @@ export class LoadingService {
   private startTime = 0;
   private readonly MIN_DISPLAY_TIME = 500;
 
-  busy() {
+  private activeOperations = new Set<string>();
+
+  busy(id?: string) {
     this.activeRequests++;
+    if (id) this.activeOperations.add(id);
+
     if (this.activeRequests === 1) {
       this.ngZone.run(() => {
         this.spinnerService.show(undefined, {
@@ -25,8 +29,10 @@ export class LoadingService {
     }
   }
 
-  idle() {
+  idle(id?: string) {
     this.activeRequests--;
+    if (id) this.activeOperations.delete(id);
+
     if (this.activeRequests <= 0) {
       const elapsedTime = Date.now() - this.startTime;
       const delayTime = Math.max(0, this.MIN_DISPLAY_TIME - elapsedTime);
@@ -41,6 +47,10 @@ export class LoadingService {
 
   isLoading() {
     return this.activeRequests > 1;
+  }
+
+  isLoadingId(id: string) {
+    return this.activeOperations.has(id);
   }
 
   /**

--- a/Frontend/src/app/services/loading.service.ts
+++ b/Frontend/src/app/services/loading.service.ts
@@ -1,52 +1,30 @@
-import { inject, Injectable, NgZone } from '@angular/core';
-import { NgxSpinnerService } from 'ngx-spinner';
+import { computed, Injectable, signal } from '@angular/core';
 
 @Injectable({
   providedIn: 'root',
 })
 export class LoadingService {
-  private spinnerService = inject(NgxSpinnerService);
-  private ngZone = inject(NgZone);
-  private activeRequests = 0;
-  private startTime = 0;
-  private readonly MIN_DISPLAY_TIME = 500;
-
+  private activeRequests = signal(0);
   private activeOperations = new Set<string>();
+  public readonly isLoading = computed(() => this.activeRequests() > 0);
 
   busy(id?: string) {
-    this.activeRequests++;
-    if (id) this.activeOperations.add(id);
-
-    if (this.activeRequests === 1) {
-      this.ngZone.run(() => {
-        this.spinnerService.show(undefined, {
-          type: 'ball-pulse',
-          bdColor: 'rgba(255, 255, 255, 0)',
-          color: '#333333',
-        });
-      });
-      this.startTime = Date.now();
+    if (id) {
+      if (this.activeOperations.has(id)) return;
+      this.activeOperations.add(id);
     }
+    this.activeRequests.update((count) => count + 1);
   }
 
   idle(id?: string) {
-    this.activeRequests--;
-    if (id) this.activeOperations.delete(id);
-
-    if (this.activeRequests <= 0) {
-      const elapsedTime = Date.now() - this.startTime;
-      const delayTime = Math.max(0, this.MIN_DISPLAY_TIME - elapsedTime);
-      this.activeRequests = 0;
-      this.ngZone.run(() => {
-        setTimeout(() => {
-          this.spinnerService.hide();
-        }, delayTime);
-      });
+    if (id) {
+      if (!this.activeOperations.has(id)) return;
+      this.activeOperations.delete(id);
     }
-  }
-
-  isLoading() {
-    return this.activeRequests > 1;
+    this.activeRequests.update((count) => count - 1);
+    if (this.activeRequests() <= 0) {
+      this.activeRequests.set(0);
+    }
   }
 
   isLoadingId(id: string) {
@@ -59,6 +37,6 @@ export class LoadingService {
    * Prevents page flash by avoiding premature rendering during loading.
    */
   canShow<T>(dependency: T | null | undefined): boolean {
-    return !this.isLoading() && dependency === null;
+    return !this.isLoading && dependency === null;
   }
 }

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -7,16 +7,20 @@ import {
   getPaginatedResult,
   getPaginationParams,
 } from '../utils/pagination.utils';
+import { LoadingService } from './loading.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UsersService {
   private http = inject(HttpClient);
+  private loadingService = inject(LoadingService);
   baseUrl = environment.apiUrl;
   paginatedResult = signal<PaginatedResult<Member[]> | null>(null);
 
-  getUsers(page?: number, pageSize?: number) {
+  getUsers(page?: number, pageSize?: number, loadingId?: string) {
+    if (loadingId) this.loadingService.busy(loadingId);
+
     return this.http
       .get<Member[]>(`${this.baseUrl}users/`, {
         observe: 'response',
@@ -24,7 +28,11 @@ export class UsersService {
       })
       .subscribe({
         next: (response) => {
+          if (loadingId) this.loadingService.idle(loadingId);
           this.paginatedResult.set(getPaginatedResult(response));
+        },
+        error: (error) => {
+          if (loadingId) this.loadingService.idle(loadingId);
         },
       });
   }

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -19,6 +19,12 @@ export class UsersService {
   paginatedResult = signal<PaginatedResult<Member[]> | null>(null);
 
   getUsers(page?: number, pageSize?: number, loadingId?: string) {
+    if (
+      (this.paginatedResult()?.pagination?.currentPage ?? -1) === page &&
+      (this.paginatedResult()?.pagination?.itemsPerPage ?? -1) === pageSize
+    ) {
+      return;
+    }
     if (loadingId) this.loadingService.busy(loadingId);
 
     return this.http


### PR DESCRIPTION
Closes #77 and #81

An "active operation" is just defined as something specific that is waiting for a response from the API. For example, the act of clicking "Create Account" is an active operation with the id 'create-account', which will remain in the activeOperations set until the request is resolved.

This PR sets up active operation loaders for #77:
- create account
- sign in account
- change username
- change password
- edit role of a user
- querying user directory page
- querying user manager page

This PR also puts a global loading indicator at the top of the site (#81), which displays a progressing bar from 0 to 85% while a request is underway, and is set to 100% when the request completes, and fades out. This is essentially a fake loading bar but big sites like YT do this too. The purpose is to show the user that an operation that requires them to wait is underway.

You can see these changes in action by throttling network in devtools to simulate below average network conditions, and see the interactive UI elements disable while the matching active operations are in progress.  

With this change, we no longer need NGX Spinner, so I've removed it.

There are some weird artifacts in this video because I compressed it to be under 10MB. Ignore them.

https://github.com/user-attachments/assets/837c1b13-7c53-4007-a0e3-73c5b551c351

Also closes #79, but I did not record the video for the change after implementing the fix for #79