### PR TITLE
[Feat] Search Params in URL, persisted through browser history assuming page change

### DIFF
--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.html
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.html
@@ -1,10 +1,6 @@
 <div>
   <p>Displaying {{ paginationText }} users.</p>
-  @if (loadingService.isLoadingId("user-manager")) {
-    <div>LOADING</div>
-  } @else if (paginatedResult) {
-    <div>LOADED DATA</div>
-  } @else {
+  @if (!loadingService.isLoadingId("user-manager") && !paginatedResult) {
     <p>Failed to load pagination data.</p>
   }
   <app-pagination-controls

--- a/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
+++ b/Frontend/src/app/components/admin/user-manager/user-manager.component.ts
@@ -8,6 +8,7 @@ import { SimpleModalComponent } from '../../modal/modal.component';
 import { AccountService } from '../../../services/account.service';
 import { HotToastService } from '@ngxpert/hot-toast';
 import { LoadingService } from '../../../services/loading.service';
+import { QUERY_PARAMS } from '../../../constants/query.constants';
 
 @Component({
   selector: 'app-user-manager',
@@ -24,8 +25,8 @@ export class UserManagerComponent {
   // We are allowing page size change on this component, so we will not be storing
   // pulled paginated data as a cache in a signal, unlike users.service.ts
   paginatedResult: PaginatedResult<UserWithRoles[]> | null = null;
-  page = signal(1);
-  pageSize = signal(10);
+  page = signal(QUERY_PARAMS.PAGE.DEFAULT);
+  pageSize = signal(QUERY_PARAMS.PAGE_SIZE.DEFAULT);
   selectedUser: UserWithRoles | null = null;
 
   availableRoles: string[] = ['Admin', 'Moderator'];

--- a/Frontend/src/app/components/pagination-controls/pagination-controls.component.ts
+++ b/Frontend/src/app/components/pagination-controls/pagination-controls.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, input, OnInit, output } from '@angular/core';
 import { PaginatedResult } from '../../models/pagination';
 import { LoadingService } from '../../services/loading.service';
+import { QUERY_PARAMS } from '../../constants/query.constants';
 
 @Component({
   selector: 'app-pagination-controls',
@@ -12,8 +13,8 @@ export class PaginationControlsComponent<T> implements OnInit {
   loadingService = inject(LoadingService);
   loadingId = input.required<string>();
 
-  minPageSize = input<number>(5);
-  maxPageSize = input<number>(50);
+  minPageSize = input<number>(QUERY_PARAMS.PAGE_SIZE.MIN);
+  maxPageSize = input<number>(QUERY_PARAMS.PAGE_SIZE.MAX);
 
   page = input.required<number>();
   pageChange = output<number>(); // for [(page)}
@@ -22,7 +23,7 @@ export class PaginationControlsComponent<T> implements OnInit {
   pageSizeChange = output<number>(); // for [(pageSize)}
 
   paginatedResult = input.required<PaginatedResult<T[]> | null>();
-  pageSizeInput = 5;
+  pageSizeInput = QUERY_PARAMS.PAGE_SIZE.MIN;
 
   // Do not allow page size editing on components that will cache the paginated data
   allowPageSizeEdit = input<boolean>(false);

--- a/Frontend/src/app/components/user-directory/user-directory.component.html
+++ b/Frontend/src/app/components/user-directory/user-directory.component.html
@@ -1,17 +1,25 @@
 <div>
   <h2>User Directory</h2>
-  @if (usersService.paginatedResult()?.pagination) {
+  @if (
+    usersService.paginatedResultMap()[page()] &&
+    usersService.paginatedResultMap()[page()].pagination
+  ) {
     <app-pagination-controls
       [(page)]="page"
       [(pageSize)]="pageSize"
-      [paginatedResult]="usersService.paginatedResult()"
+      [paginatedResult]="usersService.paginatedResultMap()[page()]"
     />
   } @else {
     <p>Failed to load pagination data.</p>
   }
-  <ul>
-    @for (user of usersService.paginatedResult()?.items; track user.id) {
-      <li>{{ user.id }}, {{ user.username }}</li>
-    }
-  </ul>
+  @if (usersService.paginatedResultMap()[page()]) {
+    <ul>
+      @for (
+        user of usersService.paginatedResultMap()[page()].items;
+        track user.id
+      ) {
+        <li>{{ user.id }}, {{ user.username }}</li>
+      }
+    </ul>
+  }
 </div>

--- a/Frontend/src/app/components/user-directory/user-directory.component.html
+++ b/Frontend/src/app/components/user-directory/user-directory.component.html
@@ -1,26 +1,20 @@
 <div>
   <h2>User Directory</h2>
-  @if (loadingService.isLoadingId("user-directory")) {
-    <div>Loading...</div>
-  } @else if (
-    usersService.paginatedResultMap()[page()] &&
-    usersService.paginatedResultMap()[page()].pagination
+  <app-pagination-controls
+    [(page)]="page"
+    [(pageSize)]="pageSize"
+    [loadingId]="'user-directory'"
+    [paginatedResult]="paginatedResult"
+  />
+  @if (
+    !loadingService.isLoadingId("user-directory") &&
+    !paginatedResult?.pagination
   ) {
-    <app-pagination-controls
-      [(page)]="page"
-      [(pageSize)]="pageSize"
-      [paginatedResult]="usersService.paginatedResultMap()[page()]"
-      loadingId="user-directory"
-    />
-  } @else {
     <p>Failed to load pagination data.</p>
   }
-  @if (usersService.paginatedResultMap()[page()]) {
+  @if (users()[0]) {
     <ul>
-      @for (
-        user of usersService.paginatedResultMap()[page()].items;
-        track user.id
-      ) {
+      @for (user of users(); track user.id) {
         <li>{{ user.id }}, {{ user.username }}</li>
       }
     </ul>

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -1,43 +1,90 @@
-import { Component, effect, inject, signal } from '@angular/core';
+import { Component, inject, signal, effect } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { UsersService } from '../../services/users.service';
-import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { CommonModule } from '@angular/common';
-import { PaginationControlsComponent } from '../pagination-controls/pagination-controls.component';
 import { LoadingService } from '../../services/loading.service';
+import { Member } from '../../models/member';
+import { PaginatedResult } from '../../models/pagination';
+import { getPaginatedResult } from '../../utils/pagination.utils';
+import { PaginationControlsComponent } from '../pagination-controls/pagination-controls.component';
+import { QUERY_PARAMS } from '../../constants/query.constants';
 
 @Component({
   selector: 'app-user-directory',
-  standalone: true,
-  imports: [CommonModule, RouterModule, PaginationControlsComponent],
   templateUrl: './user-directory.component.html',
-  styleUrl: './user-directory.component.scss',
+  imports: [PaginationControlsComponent],
 })
 export class UserDirectoryComponent {
   usersService = inject(UsersService);
   router = inject(Router);
   route = inject(ActivatedRoute);
   loadingService = inject(LoadingService);
+
+  users = signal<Member[]>([]);
   page = signal(1);
   pageSize = signal(20);
+  currentPage = signal(1);
+
+  private cache: Record<string, PaginatedResult<Member[]>> = {};
 
   constructor() {
     this.route.queryParams.subscribe((params) => {
-      const pageParam = Number(params['page']);
+      const pageParam = Number(params['p']);
       if (!isNaN(pageParam) && pageParam > 0 && this.page() != pageParam) {
         this.page.set(pageParam);
+      }
+      let pageSizeParam = Number(params['s']);
+      if (!isNaN(pageSizeParam) && this.pageSize() != pageSizeParam) {
+        pageSizeParam = Math.max(QUERY_PARAMS.PAGE_SIZE.MIN, pageSizeParam);
+        pageSizeParam = Math.min(QUERY_PARAMS.PAGE_SIZE.MAX, pageSizeParam);
+        this.pageSize.set(pageSizeParam);
       }
     });
 
     effect(() => {
       this.router.navigate([], {
         relativeTo: this.route,
-        queryParams: { page: this.page() },
+        queryParams: { p: this.page(), s: this.pageSize() },
       });
     });
   }
 
   fetchUsersEffect = effect(() => {
-    if (this.usersService.paginatedResultMap()[this.page()]) return;
-    this.usersService.getUsers(this.page(), this.pageSize(), 'user-directory');
+    const queryKey = `p=${this.page()}&s=${this.pageSize()}`;
+
+    if (this.cache[queryKey]) {
+      const current = this.users();
+      current.splice(0, current.length, ...this.cache[queryKey].items!);
+      this.currentPage.set(this.page());
+      return;
+    }
+
+    this.loadingService.busy('user-directory');
+    this.usersService.getUsers(this.page(), this.pageSize()).subscribe({
+      next: (res) => {
+        this.loadingService.idle('user-directory');
+        const result = getPaginatedResult(res);
+        this.cache[queryKey] = result;
+        const current = this.users();
+        current.splice(0, current.length, ...result.items!);
+        this.currentPage.set(this.page());
+      },
+      error: () => this.loadingService.idle('user-directory'),
+    });
   });
+
+  onPageChange(newPage: number) {
+    this.page.set(newPage);
+  }
+
+  onPageSizeChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const newSize = Number(input.value);
+    this.pageSize.set(newSize);
+    this.page.set(1);
+  }
+
+  get paginatedResult(): PaginatedResult<Member[]> | null {
+    const queryKey = `p=${this.page()}&s=${this.pageSize()}`;
+    return this.cache[queryKey] || null;
+  }
 }

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -1,8 +1,18 @@
-import { Component, effect, inject, signal } from '@angular/core';
+import {
+  Component,
+  effect,
+  inject,
+  signal,
+  OnInit,
+  OnDestroy,
+} from '@angular/core';
 import { UsersService } from '../../services/users.service';
-import { RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PaginationControlsComponent } from '../pagination-controls/pagination-controls.component';
+import { Subscription } from 'rxjs';
+import { Member } from '../../models/member';
+import { PaginatedResult } from '../../models/pagination';
 
 @Component({
   selector: 'app-user-directory',
@@ -11,12 +21,111 @@ import { PaginationControlsComponent } from '../pagination-controls/pagination-c
   templateUrl: './user-directory.component.html',
   styleUrl: './user-directory.component.scss',
 })
-export class UserDirectoryComponent {
+export class UserDirectoryComponent implements OnInit, OnDestroy {
   usersService = inject(UsersService);
+  router = inject(Router);
+  route = inject(ActivatedRoute);
   page = signal(1);
   pageSize = signal(20);
+  private skipInitialFetch = false;
+  private lastFetchedPage = -1;
+  private subscriptions = new Subscription();
 
-  fetchUsersEffect = effect(() => {
-    this.usersService.getUsers(this.page(), this.pageSize());
-  });
+  constructor() {
+    console.log('CONSTRUCTOR');
+    // --- 1. POPSTATE LISTENER: The most reliable cache check for BACK button ---
+    // This listener fires when the browser's history entry changes (Back/Forward buttons).
+    const popstateListener = (event: PopStateEvent) => {
+      const cachedUsers: PaginatedResult<Member[]> | undefined =
+        event.state?.cachedUsers;
+
+      if (cachedUsers) {
+        console.log('POPSTATE CACHE HIT! Loading data and skipping fetch.');
+        this.usersService.paginatedResult.set(cachedUsers);
+        this.skipInitialFetch = true;
+      }
+    };
+
+    // Attach the listener and make sure to clean it up.
+    window.addEventListener('popstate', popstateListener);
+    this.subscriptions.add(
+      new Subscription(() =>
+        window.removeEventListener('popstate', popstateListener),
+      ),
+    );
+
+    // 2. Parse URL and update page signal
+    // This runs on init and when URL changes (including after popstate).
+    this.route.queryParamMap.subscribe((params) => {
+      const pageParam = Number(params.get('page'));
+      if (!isNaN(pageParam) && pageParam > 0 && pageParam !== this.page()) {
+        console.log(`URL changed, setting page signal to: ${pageParam}`);
+        this.page.set(pageParam);
+      }
+    });
+
+    // 3. Data Fetch Effect: Runs whenever 'page' signal changes
+    effect(() => {
+      if (this.skipInitialFetch) {
+        console.log('Effect skipped due to cached state.');
+        // Reset flag *after* the fetch is skipped to allow future page clicks to fetch.
+        this.skipInitialFetch = false;
+        return;
+      }
+
+      const currentPage = this.page();
+      const currentSize = this.pageSize();
+      console.log('API FETCH triggered.');
+      this.usersService.getUsers(currentPage, currentSize);
+      this.lastFetchedPage = currentPage;
+    });
+
+    // 4. Update History and Save Cache State ONLY when the result arrives
+    // Only run this ONCE per paginatedResult() changes. If we add currenPage = this.page(),
+    // This ends up running twice and breaking the history states.
+    effect(() => {
+      const currentResult = this.usersService.paginatedResult();
+
+      // Only save if we have a result AND it corresponds to a forward fetch
+      if (currentResult && !this.skipInitialFetch) {
+        const pageFromResult = currentResult.pagination?.currentPage;
+
+        const urlTree = this.router.createUrlTree([], {
+          relativeTo: this.route,
+          queryParams: { page: pageFromResult },
+        });
+        const url = this.router.serializeUrl(urlTree);
+
+        // Use window.history.pushState to save the cache data.
+        window.history.pushState(
+          {
+            ...window.history.state,
+            cachedUsers: currentResult,
+          },
+          '',
+          url,
+        );
+        console.log(
+          `History pushState executed for page ${pageFromResult}. Cache saved.`,
+        );
+      }
+    });
+  }
+
+  // Use ngOnInit to perform an initial cache check if the component was just created
+  ngOnInit(): void {
+    // This handles initial page load where state might be present from a router redirect
+    const cachedUsers: PaginatedResult<Member[]> | undefined =
+      window.history.state?.cachedUsers;
+
+    if (cachedUsers) {
+      console.log('NGONINIT CACHE HIT! Loading data and skipping fetch.');
+      this.usersService.paginatedResult.set(cachedUsers);
+      this.skipInitialFetch = true;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
 }

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -1,18 +1,8 @@
-import {
-  Component,
-  effect,
-  inject,
-  signal,
-  OnInit,
-  OnDestroy,
-} from '@angular/core';
+import { Component, effect, inject, signal } from '@angular/core';
 import { UsersService } from '../../services/users.service';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PaginationControlsComponent } from '../pagination-controls/pagination-controls.component';
-import { Subscription } from 'rxjs';
-import { Member } from '../../models/member';
-import { PaginatedResult } from '../../models/pagination';
 
 @Component({
   selector: 'app-user-directory',
@@ -21,111 +11,31 @@ import { PaginatedResult } from '../../models/pagination';
   templateUrl: './user-directory.component.html',
   styleUrl: './user-directory.component.scss',
 })
-export class UserDirectoryComponent implements OnInit, OnDestroy {
+export class UserDirectoryComponent {
   usersService = inject(UsersService);
   router = inject(Router);
   route = inject(ActivatedRoute);
   page = signal(1);
   pageSize = signal(20);
-  private skipInitialFetch = false;
-  private lastFetchedPage = -1;
-  private subscriptions = new Subscription();
 
   constructor() {
-    console.log('CONSTRUCTOR');
-    // --- 1. POPSTATE LISTENER: The most reliable cache check for BACK button ---
-    // This listener fires when the browser's history entry changes (Back/Forward buttons).
-    const popstateListener = (event: PopStateEvent) => {
-      const cachedUsers: PaginatedResult<Member[]> | undefined =
-        event.state?.cachedUsers;
-
-      if (cachedUsers) {
-        console.log('POPSTATE CACHE HIT! Loading data and skipping fetch.');
-        this.usersService.paginatedResult.set(cachedUsers);
-        this.skipInitialFetch = true;
-      }
-    };
-
-    // Attach the listener and make sure to clean it up.
-    window.addEventListener('popstate', popstateListener);
-    this.subscriptions.add(
-      new Subscription(() =>
-        window.removeEventListener('popstate', popstateListener),
-      ),
-    );
-
-    // 2. Parse URL and update page signal
-    // This runs on init and when URL changes (including after popstate).
-    this.route.queryParamMap.subscribe((params) => {
-      const pageParam = Number(params.get('page'));
-      if (!isNaN(pageParam) && pageParam > 0 && pageParam !== this.page()) {
-        console.log(`URL changed, setting page signal to: ${pageParam}`);
+    this.route.queryParams.subscribe((params) => {
+      const pageParam = Number(params['page']);
+      if (!isNaN(pageParam) && pageParam > 0 && this.page() != pageParam) {
         this.page.set(pageParam);
       }
     });
 
-    // 3. Data Fetch Effect: Runs whenever 'page' signal changes
     effect(() => {
-      if (this.skipInitialFetch) {
-        console.log('Effect skipped due to cached state.');
-        // Reset flag *after* the fetch is skipped to allow future page clicks to fetch.
-        this.skipInitialFetch = false;
-        return;
-      }
-
-      const currentPage = this.page();
-      const currentSize = this.pageSize();
-      console.log('API FETCH triggered.');
-      this.usersService.getUsers(currentPage, currentSize);
-      this.lastFetchedPage = currentPage;
-    });
-
-    // 4. Update History and Save Cache State ONLY when the result arrives
-    // Only run this ONCE per paginatedResult() changes. If we add currenPage = this.page(),
-    // This ends up running twice and breaking the history states.
-    effect(() => {
-      const currentResult = this.usersService.paginatedResult();
-
-      // Only save if we have a result AND it corresponds to a forward fetch
-      if (currentResult && !this.skipInitialFetch) {
-        const pageFromResult = currentResult.pagination?.currentPage;
-
-        const urlTree = this.router.createUrlTree([], {
-          relativeTo: this.route,
-          queryParams: { page: pageFromResult },
-        });
-        const url = this.router.serializeUrl(urlTree);
-
-        // Use window.history.pushState to save the cache data.
-        window.history.pushState(
-          {
-            ...window.history.state,
-            cachedUsers: currentResult,
-          },
-          '',
-          url,
-        );
-        console.log(
-          `History pushState executed for page ${pageFromResult}. Cache saved.`,
-        );
-      }
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { page: this.page() },
+      });
     });
   }
 
-  // Use ngOnInit to perform an initial cache check if the component was just created
-  ngOnInit(): void {
-    // This handles initial page load where state might be present from a router redirect
-    const cachedUsers: PaginatedResult<Member[]> | undefined =
-      window.history.state?.cachedUsers;
-
-    if (cachedUsers) {
-      console.log('NGONINIT CACHE HIT! Loading data and skipping fetch.');
-      this.usersService.paginatedResult.set(cachedUsers);
-      this.skipInitialFetch = true;
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.unsubscribe();
-  }
+  fetchUsersEffect = effect(() => {
+    if (this.usersService.paginatedResultMap()[this.page()]) return;
+    this.usersService.getUsers(this.page(), this.pageSize());
+  });
 }

--- a/Frontend/src/app/components/user-directory/user-directory.component.ts
+++ b/Frontend/src/app/components/user-directory/user-directory.component.ts
@@ -20,9 +20,11 @@ export class UserDirectoryComponent {
   loadingService = inject(LoadingService);
 
   users = signal<Member[]>([]);
-  page = signal(1);
-  pageSize = signal(20);
-  currentPage = signal(1);
+  page = signal(QUERY_PARAMS.PAGE.DEFAULT);
+  pageSize = signal(QUERY_PARAMS.PAGE_SIZE.DEFAULT);
+  currentPage = signal(QUERY_PARAMS.PAGE.DEFAULT);
+
+  initialPageLoad = true;
 
   private cache: Record<string, PaginatedResult<Member[]>> = {};
 
@@ -41,6 +43,14 @@ export class UserDirectoryComponent {
     });
 
     effect(() => {
+      if (
+        this.initialPageLoad &&
+        this.page() === QUERY_PARAMS.PAGE.DEFAULT &&
+        this.pageSize() === QUERY_PARAMS.PAGE_SIZE.DEFAULT
+      ) {
+        this.initialPageLoad = false;
+        return;
+      }
       this.router.navigate([], {
         relativeTo: this.route,
         queryParams: { p: this.page(), s: this.pageSize() },

--- a/Frontend/src/app/constants/query.constants.ts
+++ b/Frontend/src/app/constants/query.constants.ts
@@ -1,0 +1,10 @@
+export const QUERY_PARAMS = {
+  PAGE: {
+    DEFAULT: 1,
+  },
+  PAGE_SIZE: {
+    DEFAULT: 20,
+    MIN: 5,
+    MAX: 50,
+  },
+};

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -1,67 +1,22 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { environment } from '../../environments/environment.development';
-import { PaginatedResult } from '../models/pagination';
 import { Member } from '../models/member';
-import {
-  getPaginatedResult,
-  getPaginationParams,
-} from '../utils/pagination.utils';
-import { LoadingService } from './loading.service';
+import { getPaginationParams } from '../utils/pagination.utils';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UsersService {
   private http = inject(HttpClient);
-  private loadingService = inject(LoadingService);
   baseUrl = environment.apiUrl;
   currentPageSize: number | null = null;
-  paginatedResultMap = signal<Record<number, PaginatedResult<Member[]>>>({});
-  paginatedResult = signal<PaginatedResult<Member[]> | null>(null);
 
-  getUsers(page?: number, pageSize?: number, loadingId?: string) {
-    if (
-      (this.paginatedResult()?.pagination?.currentPage ?? -1) === page &&
-      (this.paginatedResult()?.pagination?.itemsPerPage ?? -1) === pageSize
-    ) {
-      return;
-    }
-    if (loadingId) this.loadingService.busy(loadingId);
-
-    return this.http
-      .get<Member[]>(`${this.baseUrl}users/`, {
-        observe: 'response',
-        params: getPaginationParams(page, pageSize),
-      })
-      .subscribe({
-        next: (response) => {
-          const result = getPaginatedResult(response);
-
-          // if user modified page size, reset paginatedResultMap
-          if (
-            this.currentPageSize &&
-            this.currentPageSize != result.pagination.itemsPerPage
-          ) {
-            this.paginatedResultMap.set({});
-          }
-          this.currentPageSize = result.pagination.itemsPerPage;
-
-          // CAUTION: There is still a pitfall if we decide to implement sorting.
-          // Sorting data should be handled by the backend, since we dont want to
-          // return every entry then sort on the frontend.
-          // https://github.com/robchendev/CoffeeDB/issues/44
-
-          // update paginatedResultMap
-          this.paginatedResultMap.set({
-            ...this.paginatedResultMap(),
-            [result.pagination.currentPage]: result,
-          });
-        },
-        error: (error) => {
-          if (loadingId) this.loadingService.idle(loadingId);
-        },
-      });
+  getUsers(page?: number, pageSize?: number) {
+    return this.http.get<Member[]>(`${this.baseUrl}users/`, {
+      observe: 'response',
+      params: getPaginationParams(page, pageSize),
+    });
   }
 
   getUser(username: string) {

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -1,5 +1,3 @@
-// users.service.ts (Reverted to original, but simplified)
-
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 import { environment } from '../../environments/environment.development';
@@ -16,13 +14,10 @@ import {
 export class UsersService {
   private http = inject(HttpClient);
   baseUrl = environment.apiUrl;
-  // This signal is updated either by the navigation state (cache hit)
-  // or by the API call (cache miss)
-  paginatedResult = signal<PaginatedResult<Member[]> | null>(null);
+  currentPageSize: number | null = null;
+  paginatedResultMap = signal<Record<number, PaginatedResult<Member[]>>>({});
 
   getUsers(page?: number, pageSize?: number) {
-    // This function must now ONLY fetch data, as the component handles the cache check.
-    console.log(`Service: Performing API fetch for page ${page}`);
     return this.http
       .get<Member[]>(`${this.baseUrl}users/`, {
         observe: 'response',
@@ -30,7 +25,22 @@ export class UsersService {
       })
       .subscribe({
         next: (response) => {
-          this.paginatedResult.set(getPaginatedResult(response));
+          const result = getPaginatedResult(response);
+
+          // if user modified page size, reset paginatedResultMap
+          if (
+            this.currentPageSize &&
+            this.currentPageSize != result.pagination.itemsPerPage
+          ) {
+            this.paginatedResultMap.set({});
+          }
+          this.currentPageSize = result.pagination.itemsPerPage;
+
+          // update paginatedResultMap
+          this.paginatedResultMap.set({
+            ...this.paginatedResultMap(),
+            [result.pagination.currentPage]: result,
+          });
         },
       });
   }

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -36,6 +36,11 @@ export class UsersService {
           }
           this.currentPageSize = result.pagination.itemsPerPage;
 
+          // CAUTION: There is still a pitfall if we decide to implement sorting.
+          // Sorting data should be handled by the backend, since we dont want to
+          // return every entry then sort on the frontend.
+          // https://github.com/robchendev/CoffeeDB/issues/44
+
           // update paginatedResultMap
           this.paginatedResultMap.set({
             ...this.paginatedResultMap(),

--- a/Frontend/src/app/services/users.service.ts
+++ b/Frontend/src/app/services/users.service.ts
@@ -1,3 +1,5 @@
+// users.service.ts (Reverted to original, but simplified)
+
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 import { environment } from '../../environments/environment.development';
@@ -14,9 +16,13 @@ import {
 export class UsersService {
   private http = inject(HttpClient);
   baseUrl = environment.apiUrl;
+  // This signal is updated either by the navigation state (cache hit)
+  // or by the API call (cache miss)
   paginatedResult = signal<PaginatedResult<Member[]> | null>(null);
 
   getUsers(page?: number, pageSize?: number) {
+    // This function must now ONLY fetch data, as the component handles the cache check.
+    console.log(`Service: Performing API fetch for page ${page}`);
     return this.http
       .get<Member[]>(`${this.baseUrl}users/`, {
         observe: 'response',


### PR DESCRIPTION
Closes #78 

Also implements a hybrid cache, one that can be considered better than nothing, but still not very good.

In the ideal world we wouldn't need a cache, and the browser can handle caching each page for the user to click back/forward buttons on. However for that we'd need SSR, where the server returns a fully rendered HTML page. Unfortunately, since we are developing in SPA, implementing a UX like the SSR method is not easy, since we are rendering the component at the route, then fetching data from an API, then displaying that data with JS.

Instead, I opted for a hybrid approach, where a linear cache is stored at the component level, keeping track of the pages the user has visited for **that specific query**. Note that only pages are stored in cache, and it will not handle dynamic caching for results like sorting via a column. This means as soon as a sort query is added (eg. sort username by descending, sort date by descending), or the page size changes, the cache will invalidate itself and rebuild itself from scratch. Meaning, for every query, as long as the page number is the only thing changing, the cache will store and serve data when navigating back/forward via the browser functions. This isn't the most elegant approach but it's better than simply requerying each and every page.

This video demonstrates the strength and weakness of this current caching implementation. As soon as something other than the page number is changed in the query params, the cache resets.

https://github.com/user-attachments/assets/a1640e26-ce69-4576-b424-25543707891f


